### PR TITLE
[PENDING] MongoDB Simple Replicaset Member Nemesis

### DIFF
--- a/tests/jepsen/mongodb/src/jepsen/mongodb.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb.clj
@@ -105,7 +105,7 @@
                          (->> (:generator workload)
                               (gen/stagger (/ (:rate opts)))
                               (gen/nemesis (gen/phases
-                                              (gen/sleep 5)
+                                              (gen/sleep 10)
                                               (:generator nemesis)
                                             ))
                               (gen/time-limit (:time-limit opts))))})))

--- a/tests/jepsen/mongodb/src/jepsen/mongodb.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb.clj
@@ -74,6 +74,7 @@
                          ;:kill      {:targets [:all]}
                          :pause     {:targets [nil :one :primaries :majority :all]}
                          :kill      {:targets [nil :one :primaries :majority :all]}
+                         :member    {:targets [:majority]} ;; {:targets [:primary :minority :majority]}
                          :interval  (:nemesis-interval opts)})]
     (merge tests/noop-test
            opts

--- a/tests/jepsen/mongodb/src/jepsen/mongodb.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb.clj
@@ -74,7 +74,7 @@
                          ;:kill      {:targets [:all]}
                          :pause     {:targets [nil :one :primaries :majority :all]}
                          :kill      {:targets [nil :one :primaries :majority :all]}
-                         :member    {:targets [:majority]} ;; {:targets [:primary :minority :majority]}
+                         :member    {:targets [:primary :minority :majority]}
                          :interval  (:nemesis-interval opts)})]
     (merge tests/noop-test
            opts

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/db.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/db.clj
@@ -98,16 +98,16 @@
   "Starts mongod"
   [test node]
   (info "Starting mongod")
-  (c/su
-   (c/exec :mkdir :-p mongod-dir)
+  (c/su 
+    (c/exec :mkdir :-p mongod-dir)
     ;; Wipe out any old data
-   (c/exec :rm :-rf (c/lit (str database-dir "/*")))
-   (cu/start-daemon!
-    {:logfile mongod-log-file
-     :pidfile mongod-pid-file
-     :chdir mongod-dir}
-    (str "/usr/bin/" mongod-bin)
-    :--config "/etc/mongod.conf")))
+    ;; (c/exec :rm :-rf (c/lit (str database-dir "/*")))
+    (cu/start-daemon!
+      {:logfile mongod-log-file
+      :pidfile mongod-pid-file
+      :chdir mongod-dir}
+      (str "/usr/bin/" mongod-bin)
+      :--config "/etc/mongod.conf")))
 
 (defn stop!
   "Stops the mongodb service"
@@ -285,6 +285,7 @@
       ;; wait to make sure cov-server is ready
       (Thread/sleep 6000)
       (configure! test node)
+      (c/su (c/exec :rm :-rf (c/lit (str database-dir "/*")))) ;; clean specifically in setup
       (start! test node)
       (join! test node))
 

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -19,7 +19,7 @@
 (defn grace-remove-cleanup
   "The kill didn't follow the remove procedure defined by mongodb, so follow the remaining step here before adding new members
   "
-  [nodes, removed]
+  [test, replica-set-db, nodes, removed]
   ;; Now add new members step by step
   ;; 1. the kill didn't follow the remove procedure defined by mongodb, so follow here
   (let
@@ -78,7 +78,7 @@
         (info "Add member " target " new crashing status is " (deref crashing-status))
         ;; Now add new members step by step
         ;; 1. the kill didn't follow the remove procedure defined by mongodb, so follow here
-        (grace-remove-cleanup nodes removed)
+        (grace-remove-cleanup test replica-set-db nodes removed)
         ;; 2. TODO: now (re)-add new members
         ;; (let
         ;;   [

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -32,9 +32,8 @@
       ;; if there are removed members, add some back
       (let
         [
-          rnd (rand-int (+ cnt 1))  ;; rnd = 0 ~ cnt, cnt itself should be even
-          num (even? rnd rnd (+ rnd 1)) ;; if rnd is odd, add rnd + 1
-          ;; add number must be 0 ~ cnt and even
+          rnd (+ (rand-int cnt) 1)  ;; rnd = 1 ~ cnt, cnt itself should be even
+          num (if (even? rnd) rnd (+ rnd 1)) ;; ensure add > 0 and even
           target (take num (shuffle removed))
         ]
         ;; update status
@@ -66,9 +65,8 @@
       ;; if there are members available to remove, then do a random remove of even # of members
       (let
         [
-          rnd (rand-int (+ avail-cnt 1)) ;; rnd = 0 ~ avail-cnt
-          num (even? rnd rnd (- rnd 1)) ;; when rnd is odd, remove rnd - 1
-          ;; remove number must be 1 ~ avail-cnt and even
+          rnd (+ (rand-int avail-cnt) 1) ;; rnd = 1 ~ avail-cnt, where avail-cnt should be even
+          num (if (even? rnd) rnd (+ rnd 1)) ;; ensure remove > 0 and even
           target (take num (shuffle avail)) ;; randomly choose from nodes
         ]
         ;; update status

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -19,43 +19,12 @@
 (def version-cnt (
   ref 1 
   :validator pos? ;; there might need a validator
-)) 
+))
 
-(defn construct-config
-  "Construct a new config based on a old config
-
-  "
-  [test, members, old-config]
-
-  {
-    :_id (:replica-set-name test "rs_jepsen")
-    ;; :configsvr (mdb/config-server? test)
-    ;;  ; See https://docs.mongodb.com/manual/reference/replica-configuration/#rsconf.settings.catchUpTimeoutMillis
-    ;; :settings {
-    ;;   :heartbeatTimeoutSecs       1,
-    ;;   :electionTimeoutMillis      1000,
-    ;;   :catchUpTimeoutMillis       1000,
-    ;;   :catchUpTakeoverDelayMillis 3000
-    ;; }
-    ;; Each replica set member must have a unique _id. Avoid re-using _id values even if no members[n] entry is using that _id in the current configuration.
-    ;; Once set, you cannot change the _id of a member.    
-    ;; :members (->>
-    ;;   members
-    ;;   (map-indexed (fn [i node]
-    ;;                               {:_id  i
-    ;;                                :priority (if (hidden node)
-    ;;                                            0
-    ;;                                            (- (count (:nodes test)) i))
-    ;;                                :votes    (if (hidden node)
-    ;;                                            0
-    ;;                                            1)
-    ;;                                :hidden   (boolean (hidden node))
-    ;;                                :host     (str node ":"
-    ;;                                               (if (config-server? test)
-    ;;                                                 client/config-port
-    ;;                                                 client/shard-port))})))
-    }
-)
+(def member-id-cnt (
+  ref 0
+  :validate (partial <= 0)
+))
 
 
 (defn grace-remove-cleanup
@@ -114,37 +83,74 @@
 )
 
 
-(defn add-with-reconfig
-  ""
-  [test, replica-set-db, nodes, target]
-  (let
-    [
-      primary (->>
-        (cset/difference (set nodes) target) ;; calculate remaining alive nodes
-        (assoc test :nodes) ;; for following code, we only need to check alive nodes
-        (db/primaries replica-set-db)
-        (first) ;; get only the first result
+(defn reconfig-for-adding
+  "Add one member by reconfigurate the replica-set
+  "
+  [test, replica-set-db, primary, port, new-member]
+
+  (with-open [ conn (mcl/open primary port) ] ;; open a connect to the primary node
+    (let
+      [
+        old-config (:config (mcl/admin-command! conn { :replSetGetConfig 1 })) ;; get current configuration
+        id (:_id old-config)
+        old-version (deref version-cnt)
+        new-version (+ old-version 1)
+        old-member-list (:members old-config)
+        ;; Each replica set member must have a unique _id. Avoid re-using _id values even if no members[n] entry is using that _id in the current configuration.
+        new-member-id (+ (deref member-id-cnt) 1)
+        new-member-list (->>
+          ;; construct a new member document
+          ;; For now only add voting members and doesn't consider hidden problem, for simplicity set priority be 1
+          {:_id new-member-id, :votes 1, :host (str new-member ":" port), :priority 1, :hidden false} 
+          ;; add with old member list
+          (conj (vec old-member-list))
+        )
+        ;; Construct new config
+        new-config {:_id id, :version new-version, :members new-member-list}
+      ]
+      (try
+        (mcl/admin-command! conn { :replSetReconfig new-config })
+        (catch Exception e (info "Reconfig should have completed, the error is\n" e) nil)
       )
-      port (if (mdb/config-server? test) mcl/config-port mcl/shard-port)
-
-    ]
-
-    ;; should 
-
-
-    ;; db.adminCommand(
-    ;;   {
-    ;;     replSetGetConfig: 1,
-    ;;     commitmentStatus: <boolean>,
-    ;;     comment: <any>
-    ;;   }
-    ;; )
-    ;; (info "New primary after rs.remove is " primary)
-    ;; ;; (.close (mcl/await-open primary port)) ;; wait for primary to connect
-    (with-open [ conn (mcl/open primary port) ]
-      (info "In add-with-reconfig, Current config:\n\n "  (mcl/admin-command! conn { :replSetGetConfig 1 }) "\n\n") ;; get current config
+      ;; update version-cnt and member-id-cnt
+      (dosync (ref-set version-cnt new-version))
+      (dosync (ref-set member-id-cnt new-member-id))
+      (info "Added a new member: " new-member "via reconfiguration")
     )
-    
+  )
+)
+
+
+(defn add-with-reconfig
+  "Add members 1 by 1 to the replica set via re-configuration.
+  This function should emulate an admin maintaining process (i.e. has identified all failing nodes and performing updating)
+  "
+  [test, replica-set-db, nodes, targets]
+  ;; Assume 
+  ;; 1. /etc/mongod.conf on nodes doesn't need to change, stay as db setup
+  ;; 2. the data directory should have been wiped out, hence MongoDB will use its initial syncing feature to restore the data.
+
+  ;; Start the mongod
+  (jcontrol/on-nodes test targets mdb/start!)
+  ;; Get current config
+  (doall ;; enforce evaluation
+    (for [n targets]
+      (let
+        [
+          live-members (cset/difference (set nodes) targets), ;; members that are alive before add
+          live-x (first live-members)
+          port (if (mdb/config-server? test) mcl/config-port mcl/shard-port)
+        ]
+        ;; On an alive members, get the current primary from the current status of the replicaset 
+        (with-open [ live-conn (mcl/open live-x port) ]
+          (let [cur-prim (mdb/primary live-conn)] ;; this command should be able to run on any alive members
+            (info "In add-with-reconfig, Current primary is: " cur-prim)
+            ;; perform reconfig
+            (reconfig-for-adding test replica-set-db cur-prim port n)
+          )
+        )
+      )
+    )
   )
 )
 
@@ -184,11 +190,6 @@
         ;; update status
         (dosync (ref-set crashing-status (cset/difference removed (set target))))
         (info "Add member " target " new crashing status is " (deref crashing-status))
-        ;; (configure! test node) ;; seems can skip config since it should have been setup properly
-        ;; (start! test node) ;;
-        ;; (join! test node)
-        ;; (jcontrol/on-nodes test target (partial db/kill! replica-set-db))
-
       )
       (info "No adding any member")
     )
@@ -258,7 +259,8 @@
     ;; Setup the nemesis to work with the cluster. Returns the nemesis ready to be invoked.
     (setup! [this test]
       (info "Setting up member nemesis")
-      (dosync (ref-set version-cnt 1))) ;; track the version number
+      (dosync (ref-set version-cnt 1)) ;; track the version number, version start from 1
+      (dosync (ref-set member-id-cnt (- (count (:nodes test)) 1) )) ;; id starts from 0
       this
     )
 

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -57,11 +57,11 @@
   (let
     [
       nodes (:nodes test), ;; all nodes in a test
-      removed (deref crashing-status)
+      removed (deref crashing-status),
       avail (cset/difference (set nodes) removed), ;; still available nodes
       avail-cnt (- (count avail) 3) ;; # of nodes that can be removed
     ]
-
+    (info "have " avail-cnt "members can be removed. Current crashing status is ", removed)
     (if (pos? avail-cnt)
       ;; if there are members available to remove, then do a random remove of even # of members
       (let
@@ -131,10 +131,8 @@
     [
       db (:db opts),
       nodes (:nodes opts),
-      ;; rm {:type :info, :f :remove-members, :value nil},
-      ;; ad {:type :info, :f :add-members, :value nil}
-      rm (fn [_ _] {:type :info, :f :remove-members, :value nil}),
-      ad (fn [_ _] {:type :info, :f :add-members, :value nil})
+      rm (fn [_ _] {:type :info, :f :remove-members}),
+      ad (fn [_ _] {:type :info, :f :add-members})
     ]
     ;; A simple logic is to remove -> add -> remove -> add .... repeat
     (->>

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -62,14 +62,7 @@
                 ;; Construct new config
                 new-config {:_id id, :version new-version, :members new-members}
               ]
-              ;; Reconfig to remove
-              ;; (try
-                ;; the below command should act as rs.remove()
-                ;; This function will disconnect the shell briefly and forces a reconnection
-                ;; the shell will display an error even if this command succeeds
-                (mcl/admin-command! conn { :replSetReconfig new-config })
-              ;;   (catch Exception e (info "Reconfig should have completed, the error is\n" e) nil)
-              ;; )
+              (mcl/admin-command! conn { :replSetReconfig new-config })
               ;; Update version cnt
               (dosync (ref-set version-cnt new-version))
               (info "cleaned up for " n)
@@ -164,38 +157,24 @@
       live-x (first live-members),
       port (if (mdb/config-server? test) mcl/config-port mcl/shard-port)
     ]
-    ;; 2. Start the mongod for all
+    ;; 1. the kill didn't follow the remove procedure defined by mongodb, but now has minority of primary
+    ;; 2 Make sure the new member's data directory does not contain data
+    (jcontrol/on-nodes test removed mdb/wipe!)
+    ;; 3 Start the mongod for all
     (jcontrol/on-nodes test removed mdb/start!)
     (info "In FORCE, restarted mongod")
-    ;; 2. Force a reconfig
+    ;; 4. Force a reconfig
     (with-open [ live-conn (mcl/open live-x port) ]
       (let
         [
-          old-config (mcl/admin-command! live-conn { :replSetGetConfig 1 }) ;; get the current configuration
-          id (:_id old-config)
-          old-version (deref version-cnt)
-          new-version (+ old-version 1)
-          old-member-list (:members old-config)
-          ;; Each replica set member must have a unique _id. Avoid re-using _id values even if no members[n] entry is using that _id in the current configuration.
-          old-member-id (deref member-id-cnt)
-          new-member-list (->> (vec removed)
-            ;; Construct a new member document for each new member
-            ;; For now only add voting members and doesn't consider hidden problem, for simplicity set priority be 1
-            (map-indexed (fn [i to-add] {:_id (+ old-member-id i 1), :votes 1, :host (str to-add ":" port), :priority 1, :hidden false}))
-            ;; add with old member list
-            (concat (vec old-member-list))
-          )
-          ;; Construct new config with force
-          new-config {:_id id, :version new-version, :members new-member-list, :force true}
+          old-config (:config (mcl/admin-command! live-conn { :replSetGetConfig 1 })) ;; get the current configuration
         ]
-        (info "The new FORCE config is:\n" new-config)
+        (info "The recovered config via FORCE is:\n" old-config)
         ;; enforce a reconfig
         ;; according to MongoDB, the configuration is then propagated to all the surviving members listed in the members array. The replica set will then
         ;; elects a new primary.
-        (mcl/admin-command! live-conn { :replSetReconfig new-config })
-        ;; update version-cnt and member-id-cnt
-        (dosync (ref-set version-cnt new-version))
-        (dosync (ref-set member-id-cnt (+ old-member-id (count removed))))
+        ;; Don't need to update the config, otherwise the "force" command would complain
+        (mcl/admin-command! live-conn { :replSetReconfig old-config, :force true })
         (info "End of FORCE reconfig. Added " removed "via force reconfiguration.")
       )
     )
@@ -218,31 +197,19 @@
       replica-set-db (:db test)
     ]
 
-    ;; 1. the kill didn't follow the remove procedure defined by mongodb, so follow here
-    (grace-remove-cleanup test replica-set-db nodes removed)
-    ;; 2.1 Make sure the new member's data directory does not contain data
-    (jcontrol/on-nodes test removed mdb/wipe!)
-    (info "Should have removed old data")
-
-    ;; (if (pos? cnt)
     (if (>= remaining-cnt 3)
       ;; if the replica set has more than 3 members, can just add with reconfig
       (let
         [
-          ;; rnd (+ (rand-int cnt) 1),  ;; rnd = 1 ~ cnt, cnt itself should be even
-          ;; num (if (even? rnd) rnd (+ rnd 1)), ;; ensure add > 0 and even
-          ;; target (take num (shuffle removed)),
-          target (set removed), ;; add back all removed
-          ;; replica-set-db (:db test)
-          ;; nodes (:nodes test)
+          target (set removed)
         ]
         ;; Now add new members step by step
         ;; 1. the kill didn't follow the remove procedure defined by mongodb, so follow here
-        ;; (grace-remove-cleanup test replica-set-db nodes removed)
+        (grace-remove-cleanup test replica-set-db nodes removed)
         ;; 2. now (re)-add new members
         ;; 2.1 Make sure the new member's data directory does not contain data
-        ;; (jcontrol/on-nodes test removed mdb/wipe!)
-        ;; (info "Should have removed old data")
+        (jcontrol/on-nodes test removed mdb/wipe!)
+        (info "Should have removed old data")
         ;; 2.2 Add the new member into the replica set
         (add-with-reconfig test replica-set-db nodes target)
 
@@ -273,7 +240,7 @@
       db (:db test)
       saft-num (- (count nodes) 3)
       minority-num (+ (rand-int saft-num) 1) ;; = 1 ~ saftnum
-      majority-num (- (count nodes) (+ (rand-int 2) 1)) ;;(inc (int (Math/floor (/ n 2)))) ;; = total number - 2
+      majority-num (- (count nodes) (+ (rand-int 2) 1)) ;; = total number - 1/2
     ]
     (case options
       :primary    (set (db/primaries db test)) ;; here assume all nodes should be available

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -7,21 +7,6 @@
                 [jepsen.generator :as jgen]
                 [jepsen.mongodb.db :as db]))
 
-(defn add-members
-  "Add voting members into the replica set.
-  As required by MongoDB, assume add even numbers of members.
-  "
-  [targets]
-  (info targets "joining the replica set" )
-)
-
-(defn force-remove-members
-  "Forcibly remove voting members from the replica set (i.e. kill mongod process) to simulate crashes
-  As required by MongoDB, assume remove even numbers of members 
-  "
-  [targets]
-  (info targets "leaving the replica set" )
-)
 
 ;; use a set to record the removed nodes
 (def crashing-status (
@@ -29,8 +14,74 @@
   ;; :validator pos? ;; there might need a validator
 )) 
 
-;; Only here can find all nodes at "test"
-;; then here is the place where we should tracking the removed nodes
+
+(defn add-members
+  "Add voting members into the replica set.
+  As required by MongoDB, assume add even numbers of members.
+  "
+  [test]
+  (info targets "joining the replica set" )
+  (let
+    [
+      removed (deref crashing-status) ;; removed count should always be even
+      cnt (count removed)
+    ]
+
+    (pos? cnt
+      ;; if there are removed members, add some back
+      (let
+        [
+          rnd (rand-int (+ cnt 1))  ;; rnd = 0 ~ cnt, cnt itself should be even
+          num (even? rnd rnd (+ rnd 1)) ;; if rnd is odd, add rnd + 1
+          ;; add number must be 0 ~ cnt and even
+          target (take num (shuffle removed))
+        ]
+        ;; update status
+        (dosync (ref-set crashing-status (difference removed (set target))))
+        (info "Add member " target " new crashing status is " (deref crashing-status))
+        ;; TODO: add members as steps
+      )
+      (info "No adding any member")
+    )
+  )
+)
+
+
+(defn force-remove-members
+  "Forcibly remove voting members from the replica set (i.e. kill mongod process) to simulate crashes
+  As required by MongoDB, assume remove even numbers of members 
+  "
+  [test]
+  (info "Start removing members")
+  (let
+    [
+      nodes (:nodes test), ;; all nodes in a test
+      removed (deref crashing-status)
+      avail (difference (set nodes) removed), ;; still available nodes
+      avail-cnt (- (count avail) 3) ;; # of nodes that can be removed
+    ]
+
+    (pos? avail-cnt
+      ;; if there are members available to remove, then do a random remove of even # of members
+      (let
+        [
+          rnd (rand-int (+ avail-cnt 1)) ;; rnd = 0 ~ avail-cnt
+          num (even? rnd rnd (- rnd 1)) ;; when rnd is odd, remove rnd - 1
+          ;; remove number must be 1 ~ avail-cnt and even
+          target (take num (shuffle avail)) ;; randomly choose from nodes
+        ]
+        ;; update status
+        (dosync (ref-set crashing-status (union removed (set target))))
+        (info "remove nodes " target " new crashing status is " (deref crashing-status))
+        ;; TODO: should just kill these nodes
+      )
+      ;; otherwise, just not removing any node
+      (info "Not removing any node")
+    )
+  )
+)
+
+
 (defn member-nemesis
   "A nemesis for adding and removing member from the replica set with only voting members.
   
@@ -62,35 +113,38 @@
       (assoc op :value
         (case (:f op)
           :add-member     (add-members test) ;; TODO
-          :remove-member   (force-remove-members test) ;; TODO
-        ))) 
+          :remove-members   (force-remove-members test) ;; TODO
+        ))
+    ) 
 
     ;; Teardown the nemesis when work is complete
-    (teardown! [this test] (info node "Setting up member nemesis"))
+    (teardown! [this test] (info node "Tearing down member nemesis"))
 )
 
-;; Only here can find all nodes at "test"
-;; then here is the place where we should tracking the removed nodes
+
 (defn member-generator
   "A generator for member nemesis."
   [opts]
-  (let [
-    db (:db opts),
-    
-    rm {:type :info, :f :force-remove-members, :value (rand-nth targets)}, ;; TODO - need to choose from available nodes
-    st {:type :info, :f :add-members, :value (rand-nth targets)}, ;; TODO - need to choose from removed nodes
-  ])
-  ;; A simple logic is to remove -> add -> remove -> add .... repeat
-  (->>
-    (gen/flip-flop rm st)
-    (gen/stagger (:interval opts default-interval))
+  (let
+    [
+      db (:db opts),
+      nodes: (:nodes opts),
+      rm {:type :info, :f :remove-members},
+      ad {:type :info, :f :add-members}
+    ]
+    ;; A simple logic is to remove -> add -> remove -> add .... repeat
+    (->>
+      (gen/flip-flop rm ad)
+      (gen/stagger (:interval opts default-interval))
+    )
   )
 )
 
 
 (defn member-package
   "A combined nemesis package for adding and removing members from/to the replica set."
-  ;; mongodb.clj line 67 sets most of input opts
+  ;; mongodb.clj line 67 sets most of input opts, specifically specified
+  ;; :db, :nodes, :faults, :interval, and targets for each nemesis
   [opts]
   ;; Only return when required, i.e. --nemesis member
   (when ((:faults opts) :member)

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -273,7 +273,7 @@
       db (:db test)
       saft-num (- (count nodes) 3)
       minority-num (+ (rand-int saft-num) 1) ;; = 1 ~ saftnum
-      majority-num (- (count nodes) (+ (rand-int 2) 1)) ;; = total number - (1 ~ 2)
+      majority-num (- (count nodes) (+ (rand-int 2) 1)) ;;(inc (int (Math/floor (/ n 2)))) ;; = total number - 2
     ]
     (case options
       :primary    (set (db/primaries db test)) ;; here assume all nodes should be available
@@ -297,30 +297,13 @@
       nodes (:nodes test), ;; all nodes in a test
       replica-set-db (:db test)
       target (parse-options test options)
-      ;; removed (deref crashing-status),
-      ;; avail (cset/difference (set nodes) removed), ;; still available nodes
-      ;; avail-cnt (- (count avail) 3) ;; # of nodes that can be removed
     ]
-    ;; (info "have " avail-cnt "members can be removed. Current crashing status is ", removed)
-    ;; (if (pos? avail-cnt)
-      ;; if there are members available to remove, then do a random remove of # of members
-      ;; (let
-      ;;   [
-      ;;     ;; rnd (+ (rand-int avail-cnt) 1), ;; rnd = 1 ~ avail-cnt, where avail-cnt should be even
-      ;;     ;; num (if (even? rnd) rnd (+ rnd 1)), ;; ensure remove > 0 and even
-      ;;     ;; num (+ (rand-int avail-cnt) 1), ;; num = 1 ~ avail-cnt
-      ;;     ;; target (take num (shuffle avail)) ;; randomly choose from nodes
-      ;;     replica-set-db (:db test)
-      ;;   ]
-        ;; apply kill on all the targets
-        (jcontrol/on-nodes test target (partial db/kill! replica-set-db))
-        ;; update status
-        (dosync (ref-set crashing-status (set target)))
-        (info "remove nodes " target " new crashing status is " (deref crashing-status))
-      ;; )
-      ;; otherwise, just not removing any node
-      ;; (info "Not removing any node")
-    ;; )
+    (info "Removing " target " in remove-members")
+    ;; apply kill on all the targets
+    (jcontrol/on-nodes test target (partial db/kill! replica-set-db))
+    ;; update status
+    (dosync (ref-set crashing-status (set target)))
+    (info "remove nodes " target " new crashing status is " (deref crashing-status))
   )
 )
 
@@ -376,9 +359,9 @@
   [opts]
   (let
     [
-      remove-options (:targets (:member opts) [:primary :minority :majority])
+      remove-options (:targets (:member opts) [:primary :minority :majority]),
       rm (fn [_ _] {:type :info, :f :remove-members, :value (rand-nth remove-options)}),
-      ad (fn [_ _] {:type :info, :f :add-members}, :value :all)
+      ad (fn [_ _] {:type :info, :f :add-members, :value :all})
     ]
     ;; A simple logic is to remove -> add -> remove -> add .... repeat
     (->>

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -16,37 +16,92 @@
   ;; :validator pos? ;; there might need a validator
 )) 
 
+(def version-cnt (
+  ref #{} 
+  ;; :validator pos? ;; there might need a validator
+)) 
+
+(defn construct-config
+  "Construct a new config based on a old config
+
+  "
+  [test, members, old-config]
+
+  {
+    :_id (:replica-set-name test "rs_jepsen")
+    ;; :configsvr (mdb/config-server? test)
+    ;;  ; See https://docs.mongodb.com/manual/reference/replica-configuration/#rsconf.settings.catchUpTimeoutMillis
+    ;; :settings {
+    ;;   :heartbeatTimeoutSecs       1,
+    ;;   :electionTimeoutMillis      1000,
+    ;;   :catchUpTimeoutMillis       1000,
+    ;;   :catchUpTakeoverDelayMillis 3000
+    ;; }
+    ;; Each replica set member must have a unique _id. Avoid re-using _id values even if no members[n] entry is using that _id in the current configuration.
+    ;; Once set, you cannot change the _id of a member.    
+    :members (->>
+      members
+      (map-indexed (fn [i node]
+                                  {:_id  i
+                                   :priority (if (hidden node)
+                                               0
+                                               (- (count (:nodes test)) i))
+                                   :votes    (if (hidden node)
+                                               0
+                                               1)
+                                   :hidden   (boolean (hidden node))
+                                   :host     (str node ":"
+                                                  (if (config-server? test)
+                                                    client/config-port
+                                                    client/shard-port))})))}
+)
+
+
 (defn grace-remove-cleanup
   "The kill didn't follow the remove procedure defined by mongodb, so follow the remaining step here before adding new members
+  This function should emulate an admin maintaining process (i.e. has identified all failing nodes and performing updating)
   "
   [test, replica-set-db, nodes, removed]
-  ;; Now add new members step by step
-  ;; 1. the kill didn't follow the remove procedure defined by mongodb, so follow here
+  ;; According to Mongodb, it allows adding or removing no more than 1 voting member at a time. So perform one by one
   (let
     [
-      cur_prim (->>
-        (cset/difference (set nodes) removed) ;; calculate remaining alive nodes
-        (assoc test :nodes) ;; for following code, we only need to check alive nodes
-        (db/primaries replica-set-db)
-        (first) ;; get only the first result
-      ) ;; determing current primary
       port (if (mdb/config-server? test) mcl/config-port mcl/shard-port)
-      host-port-list (-> (fn [n] (str n ":" port))
-        (map removed)
-        vec
-      ) ;; get a vector of to removed
+      rm-seq (seq removed)
+      ;; live-members (cset/difference (set nodes) removed)
     ]
-    (info "primary before add is " cur_prim)
-    (info "finish up remove before add on " host-port-list)
-    ;; let primary finish remaing remove steps
-    (with-open [ conn (mcl/open cur_prim port) ]
-      ;; (info "Current config\n: "  (mcl/admin-command! conn { :replSetGetConfig 1 })) ;; get current config
-      ;; the below command should act as rs.remove()
-      ;; This function will disconnect the shell briefly and forces a reconnection
-      ;; the shell will display an error even if this command succeeds
-      (try
-        (mcl/admin-command! conn { :dropConnections 1, :hostAndPort host-port-list })
-        (catch Exception e (info "drop should have completed") nil)
+    (for [n rm-seq]
+      (let
+        [
+          cur_prim (->>
+            (cset/difference (set nodes) removed) ;; calculate remaining alive nodes
+            (assoc test :nodes) ;; for following code, we only need to check alive nodes
+            (db/primaries replica-set-db)
+            (first));; get only the first result
+        ]
+        (info "current primary is " cur_prim)
+        
+        (with-open [ conn (mcl/open cur_prim port) ]
+          (let
+            [
+              old-config (:config (mcl/admin-command! conn { :replSetGetConfig 1 }))
+              id (:_id old-config)
+              ;; new-version (+ (:version old-config) 1)
+              ;; TODO: get the member list by removing 1 member
+              new-members (vec (filter #(not= (:host %) n) (:members old-config)))
+              ;; TODO: construct new config
+              new-config {:_id id, :members new-members}
+            ]
+            ;; TODO: call reconfig
+            (try
+              ;; the below command should act as rs.remove()
+              ;; This function will disconnect the shell briefly and forces a reconnection
+              ;; the shell will display an error even if this command succeeds
+              (mcl/admin-command! conn { :replSetReconfig new-config })
+              (catch Exception e (info "Reconfig should have completed, the error is\n" e) nil)
+            )
+            (info "cleaned up for " n)
+          )
+        )
       )
     )
   )
@@ -65,7 +120,12 @@
         (first) ;; get only the first result
       )
       port (if (mdb/config-server? test) mcl/config-port mcl/shard-port)
+
     ]
+
+    ;; should 
+
+
     ;; db.adminCommand(
     ;;   {
     ;;     replSetGetConfig: 1,
@@ -73,11 +133,11 @@
     ;;     comment: <any>
     ;;   }
     ;; )
-    (info "New primary after rs.remove is " primary)
-    ;; (.close (mcl/await-open primary port)) ;; wait for primary to connect
-    (with-open [ conn (mcl/open primary port) ]
-      (info "Current config\n: "  (mcl/admin-command! conn { :replSetGetConfig 1 })) ;; get current config
-    )
+    ;; (info "New primary after rs.remove is " primary)
+    ;; ;; (.close (mcl/await-open primary port)) ;; wait for primary to connect
+    ;; (with-open [ conn (mcl/open primary port) ]
+    ;;   (info "Current config\n: "  (mcl/admin-command! conn { :replSetGetConfig 1 })) ;; get current config
+    ;; )
     
   )
 )
@@ -158,9 +218,6 @@
         (info "remove nodes " target " new crashing status is " (deref crashing-status))
         ;; apply kill on all the targets
         (jcontrol/on-nodes test target (partial db/kill! replica-set-db))
-        ;; seems below code cannot give primary, timeout when while waiting to connect
-        ;; (Thread/sleep 5000)
-        ;; (info "new primary is " (db/primaries replica-set-db test))
       )
       ;; otherwise, just not removing any node
       (info "Not removing any node")
@@ -193,7 +250,11 @@
   
     jnem/Nemesis
     ;; Setup the nemesis to work with the cluster. Returns the nemesis ready to be invoked.
-    (setup! [this test] (info "Setting up member nemesis") this)
+    (setup! [this test]
+      (info "Setting up member nemesis")
+      (dosync (ref-set version-cnt (count (:nodes test)))) ;; track the version number
+      this
+    )
 
     ;; Invoke - perform acture add and remove of members
     (invoke! [this test op]

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -1,0 +1,105 @@
+(ns jepsen.mongodb.member-nem
+    "A nemesis about adding and removing members from replica set"
+    (:require   [clojure.tools.logging :refer :all]
+                [jepsen [nemesis :as jnem]
+                        [net :as jnet]
+                        [util :as jutil]]
+                [jepsen.generator :as jgen]
+                [jepsen.mongodb.db :as db]))
+
+(defn add-members
+  "Add voting members into the replica set.
+  As required by MongoDB, assume add even numbers of members.
+  "
+  [targets]
+  (info targets "joining the replica set" )
+)
+
+(defn force-remove-members
+  "Forcibly remove voting members from the replica set (i.e. kill mongod process) to simulate crashes
+  As required by MongoDB, assume remove even numbers of members 
+  "
+  [targets]
+  (info targets "leaving the replica set" )
+)
+
+;; use a set to record the removed nodes
+(def crashing-status (
+  ref #{}
+  ;; :validator pos? ;; there might need a validator
+)) 
+
+;; Only here can find all nodes at "test"
+;; then here is the place where we should tracking the removed nodes
+(defn member-nemesis
+  "A nemesis for adding and removing member from the replica set with only voting members.
+  
+  Support 2 actions
+  - add: add new voting members into the replica set
+  - remove: remove existing voting members from the replica set
+  
+  As required by MongoDB:
+  - A replica set should have at least 3 voting nodes.
+  - A replica set should always have an odd number of voting members.
+  - A replica set can have up to 50 members, but only up to 7 voting members, all other embers must be non-voting members.
+  (details https://www.mongodb.com/docs/manual/core/replica-set-architectures/#determine-the-number-of-members)
+
+  Adding and removing steps are stated on https://www.mongodb.com/docs/manual/tutorial/expand-replica-set/#requirements
+  "
+  [opts]
+
+  (reify
+    ;; Reflection defines "What :f functions does this nemesis support?"
+    n/Reflection
+    (fs [_] [:add-member :remove-member]))
+
+    n/Nemesis
+    ;; Setup the nemesis to work with the cluster. Returns the nemesis ready to be invoked.
+    (setup! [this test] (info node "Setting up member nemesis"))
+
+    ;; Invoke - perform acture add and remove of members
+    (invoke! [this test op]
+      (assoc op :value
+        (case (:f op)
+          :add-member     (add-members test) ;; TODO
+          :remove-member   (force-remove-members test) ;; TODO
+        ))) 
+
+    ;; Teardown the nemesis when work is complete
+    (teardown! [this test] (info node "Setting up member nemesis"))
+)
+
+;; Only here can find all nodes at "test"
+;; then here is the place where we should tracking the removed nodes
+(defn member-generator
+  "A generator for member nemesis."
+  [opts]
+  (let [
+    db (:db opts),
+    
+    rm {:type :info, :f :force-remove-members, :value (rand-nth targets)}, ;; TODO - need to choose from available nodes
+    st {:type :info, :f :add-members, :value (rand-nth targets)}, ;; TODO - need to choose from removed nodes
+  ])
+  ;; A simple logic is to remove -> add -> remove -> add .... repeat
+  (->>
+    (gen/flip-flop rm st)
+    (gen/stagger (:interval opts default-interval))
+  )
+)
+
+
+(defn member-package
+  "A combined nemesis package for adding and removing members from/to the replica set."
+  ;; mongodb.clj line 67 sets most of input opts
+  [opts]
+  ;; Only return when required, i.e. --nemesis member
+  (when ((:faults opts) :member)
+    {
+      :nemesis   (member-nemesis opts)
+      :generator (member-generator opts)
+      :perf      #{
+        {:name "add-members", :fs [:add-members], :color "#E9A0E6"}
+        {:name "remove-members", :fs [:force-remove-members], :color "#ACA0E9"}
+      }})
+)
+

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -3,10 +3,10 @@
     (:require   [clojure.tools.logging :refer :all]
                 [clojure.set :as cset]
                 [jepsen [nemesis :as jnem]
-                        [net :as jnet]
-                        [util :as jutil]]
+                        [control :as jcontrol]
+                        [db :as db]]
                 [jepsen.generator :as jgen]
-                [jepsen.mongodb.db :as db]))
+                [jepsen.mongodb.db :as mdb]))
 
 
 ;; use a set to record the removed nodes
@@ -65,14 +65,18 @@
       ;; if there are members available to remove, then do a random remove of even # of members
       (let
         [
-          rnd (+ (rand-int avail-cnt) 1) ;; rnd = 1 ~ avail-cnt, where avail-cnt should be even
-          num (if (even? rnd) rnd (+ rnd 1)) ;; ensure remove > 0 and even
+          rnd (+ (rand-int avail-cnt) 1), ;; rnd = 1 ~ avail-cnt, where avail-cnt should be even
+          num (if (even? rnd) rnd (+ rnd 1)), ;; ensure remove > 0 and even
           target (take num (shuffle avail)) ;; randomly choose from nodes
+          replica-set-db (:db test)
         ]
         ;; update status
         (dosync (ref-set crashing-status (cset/union removed (set target))))
         (info "remove nodes " target " new crashing status is " (deref crashing-status))
-        ;; TODO: should just kill these nodes
+        ;; apply kill on all the targets
+        (jcontrol/on-nodes test target (partial db/kill! replica-set-db))
+        (Thread/sleep 5000)
+        (info "new primary is " (db/primaries replica-set-db test))
       )
       ;; otherwise, just not removing any node
       (info "Not removing any node")
@@ -127,8 +131,8 @@
   [opts]
   (let
     [
-      db (:db opts),
-      nodes (:nodes opts),
+      ;; db (:db opts),
+      ;; nodes (:nodes opts),
       rm (fn [_ _] {:type :info, :f :remove-members}),
       ad (fn [_ _] {:type :info, :f :add-members})
     ]

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -48,7 +48,7 @@
 )
 
 
-(defn force-remove-members
+(defn remove-members
   "Forcibly remove voting members from the replica set (i.e. kill mongod process) to simulate crashes
   As required by MongoDB, assume remove even numbers of members 
   "
@@ -103,18 +103,18 @@
   (reify
     ;; Reflection defines "What :f functions does this nemesis support?"
     jnem/Reflection
-    (fs [_] [:add-member :remove-member])
+    (fs [this] #{:add-members :remove-members})
   
     jnem/Nemesis
     ;; Setup the nemesis to work with the cluster. Returns the nemesis ready to be invoked.
-    (setup! [this test] (info "Setting up member nemesis"))
+    (setup! [this test] (info "Setting up member nemesis") this)
 
     ;; Invoke - perform acture add and remove of members
     (invoke! [this test op]
       (assoc op :value
         (case (:f op)
-          :add-member     (add-members test) ;; TODO
-          :remove-members   (force-remove-members test) ;; TODO
+          :add-members     (add-members test) ;; TODO
+          :remove-members   (remove-members test) ;; TODO
         ))
     ) 
 
@@ -131,8 +131,10 @@
     [
       db (:db opts),
       nodes (:nodes opts),
-      rm {:type :info, :f :remove-members},
-      ad {:type :info, :f :add-members}
+      ;; rm {:type :info, :f :remove-members, :value nil},
+      ;; ad {:type :info, :f :add-members, :value nil}
+      rm (fn [_ _] {:type :info, :f :remove-members, :value nil}),
+      ad (fn [_ _] {:type :info, :f :add-members, :value nil})
     ]
     ;; A simple logic is to remove -> add -> remove -> add .... repeat
     (->>
@@ -154,8 +156,8 @@
       :nemesis   (member-nemesis opts)
       :generator (member-generator opts)
       :perf      #{
-        {:name "add-members", :fs [:add-members], :color "#E9A0E6"}
-        {:name "remove-members", :fs [:force-remove-members], :color "#ACA0E9"}
-      }})
+        {:name "member", :start #{:remove-members}, :stop #{:add-members}, :color "#E9A0E6"}
+      }
+    })
 )
 

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -171,7 +171,7 @@
     (with-open [ live-conn (mcl/open live-x port) ]
       (let
         [
-          cur-config (mcl/admin-command! live-conn { replSetGetConfig: 1 }) ;; get the current configuration
+          old-config (mcl/admin-command! live-conn { :replSetGetConfig 1 }) ;; get the current configuration
           id (:_id old-config)
           old-version (deref version-cnt)
           new-version (+ old-version 1)
@@ -181,7 +181,7 @@
           new-member-list (->> (vec removed)
             ;; Construct a new member document for each new member
             ;; For now only add voting members and doesn't consider hidden problem, for simplicity set priority be 1
-            (map-indexed (fn [i to-add] {:_id (+ new-member-id-base i 1), :votes 1, :host (str to-add ":" port), :priority 1, :hidden false}))
+            (map-indexed (fn [i to-add] {:_id (+ old-member-id i 1), :votes 1, :host (str to-add ":" port), :priority 1, :hidden false}))
             ;; add with old member list
             (concat (vec old-member-list))
           )

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -6,7 +6,8 @@
                         [control :as jcontrol]
                         [db :as db]]
                 [jepsen.generator :as jgen]
-                [jepsen.mongodb.db :as mdb]))
+                [jepsen.mongodb [db :as mdb]
+                                [client :as mcl]]))
 
 
 ;; use a set to record the removed nodes
@@ -15,6 +16,40 @@
   ;; :validator pos? ;; there might need a validator
 )) 
 
+(defn grace-remove-cleanup
+  "The kill didn't follow the remove procedure defined by mongodb, so follow the remaining step here before adding new members
+  "
+  [nodes, removed]
+  ;; Now add new members step by step
+  ;; 1. the kill didn't follow the remove procedure defined by mongodb, so follow here
+  (let
+    [
+      cur_prim (->>
+        (cset/difference (set nodes) removed) ;; calculate remaining alive nodes
+        (assoc test :nodes) ;; for following code, we only need to check alive nodes
+        (db/primaries replica-set-db)
+        (first) ;; get only the first result
+      ) ;; determing current primary
+      port mcl/config-port
+      host-port-list (-> (fn [n] (str n ":" port))
+        (map removed)
+        vec
+      ) ;; get a vector of to removed
+    ]
+    (info "primary before add is " cur_prim)
+    (info "finish up remove before add on " host-port-list)
+    ;; let primary finish remaing remove steps
+    (with-open [ conn (mcl/open cur_prim port) ]
+      ;; the below command should act as rs.remove()
+      ;; This function will disconnect the shell briefly and forces a reconnection
+      ;; the shell will display an error even if this command succeeds
+      (try
+        (mcl/admin-command! conn { :dropConnections 1, :hostAndPort host-port-list })
+        (catch Exception e (info "drop should have completed") nil)
+      )
+    )
+  )
+)
 
 (defn add-members
   "Add voting members into the replica set.
@@ -32,14 +67,47 @@
       ;; if there are removed members, add some back
       (let
         [
-          rnd (+ (rand-int cnt) 1)  ;; rnd = 1 ~ cnt, cnt itself should be even
-          num (if (even? rnd) rnd (+ rnd 1)) ;; ensure add > 0 and even
-          target (take num (shuffle removed))
+          rnd (+ (rand-int cnt) 1),  ;; rnd = 1 ~ cnt, cnt itself should be even
+          num (if (even? rnd) rnd (+ rnd 1)), ;; ensure add > 0 and even
+          target (take num (shuffle removed)),
+          replica-set-db (:db test),
+          nodes (:nodes test)
         ]
         ;; update status
         (dosync (ref-set crashing-status (cset/difference removed (set target))))
         (info "Add member " target " new crashing status is " (deref crashing-status))
-        ;; TODO: add members as steps
+        ;; Now add new members step by step
+        ;; 1. the kill didn't follow the remove procedure defined by mongodb, so follow here
+        (grace-remove-cleanup nodes removed)
+        ;; 2. TODO: now (re)-add new members
+        ;; (let
+        ;;   [
+        ;;     cur_prim (->>
+        ;;       (cset/difference (set nodes) removed) ;; calculate remaining alive nodes
+        ;;       (assoc test :nodes) ;; for following code, we only need to check alive nodes
+        ;;       (db/primaries replica-set-db)
+        ;;       (first) ;; get only the first result
+        ;;     ) ;; determing current primary
+        ;;     port mcl/config-port
+        ;;     host-port-list (-> (fn [n] (str n ":" port))
+        ;;       (map removed)
+        ;;       vec
+        ;;     ) ;; get a vector of to removed
+        ;;   ]
+        ;;   (info "primary before add is " cur_prim)
+        ;;   (info "finish up remove before add on " host-port-list)
+        ;;   ;; let primary finish remaing remove steps
+        ;;   (with-open [ conn (mcl/open cur_prim port) ]
+        ;;     ;; the below command should act as rs.remove()
+        ;;     ;; This function will disconnect the shell briefly and forces a reconnection
+        ;;     ;; the shell will display an error even if this command succeeds
+        ;;     (try
+        ;;       (mcl/admin-command! conn { :dropConnections 1, :hostAndPort host-port-list })
+        ;;       (catch Exception e (info "drop should have completed") nil)
+        ;;     )
+        ;;   )
+        ;;   ;;
+        ;; )
       )
       (info "No adding any member")
     )
@@ -75,8 +143,9 @@
         (info "remove nodes " target " new crashing status is " (deref crashing-status))
         ;; apply kill on all the targets
         (jcontrol/on-nodes test target (partial db/kill! replica-set-db))
-        (Thread/sleep 5000)
-        (info "new primary is " (db/primaries replica-set-db test))
+        ;; seems below code cannot give primary, timeout when while waiting to connect
+        ;; (Thread/sleep 5000)
+        ;; (info "new primary is " (db/primaries replica-set-db test))
       )
       ;; otherwise, just not removing any node
       (info "Not removing any node")

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -106,9 +106,9 @@
           (conj (vec old-member-list))
         )
         ;; Construct new config
-        (info "New member list is: ", new-member-list)
         new-config {:_id id, :version new-version, :members new-member-list}
       ]
+      (info "New member list is: ", new-member-list)
       (try
         (mcl/admin-command! conn { :replSetReconfig new-config })
         (catch Exception e (info "Reconfig should have completed, the error is\n" e) nil)

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -1,6 +1,7 @@
 (ns jepsen.mongodb.member-nem
     "A nemesis about adding and removing members from replica set"
     (:require   [clojure.tools.logging :refer :all]
+                [clojure.set :as cset]
                 [jepsen [nemesis :as jnem]
                         [net :as jnet]
                         [util :as jutil]]
@@ -20,14 +21,14 @@
   As required by MongoDB, assume add even numbers of members.
   "
   [test]
-  (info targets "joining the replica set" )
+  (info "joining the replica set" )
   (let
     [
       removed (deref crashing-status) ;; removed count should always be even
       cnt (count removed)
     ]
 
-    (pos? cnt
+    (if (pos? cnt)
       ;; if there are removed members, add some back
       (let
         [
@@ -37,7 +38,7 @@
           target (take num (shuffle removed))
         ]
         ;; update status
-        (dosync (ref-set crashing-status (difference removed (set target))))
+        (dosync (ref-set crashing-status (cset/difference removed (set target))))
         (info "Add member " target " new crashing status is " (deref crashing-status))
         ;; TODO: add members as steps
       )
@@ -57,11 +58,11 @@
     [
       nodes (:nodes test), ;; all nodes in a test
       removed (deref crashing-status)
-      avail (difference (set nodes) removed), ;; still available nodes
+      avail (cset/difference (set nodes) removed), ;; still available nodes
       avail-cnt (- (count avail) 3) ;; # of nodes that can be removed
     ]
 
-    (pos? avail-cnt
+    (if (pos? avail-cnt)
       ;; if there are members available to remove, then do a random remove of even # of members
       (let
         [
@@ -71,7 +72,7 @@
           target (take num (shuffle avail)) ;; randomly choose from nodes
         ]
         ;; update status
-        (dosync (ref-set crashing-status (union removed (set target))))
+        (dosync (ref-set crashing-status (cset/union removed (set target))))
         (info "remove nodes " target " new crashing status is " (deref crashing-status))
         ;; TODO: should just kill these nodes
       )
@@ -101,12 +102,12 @@
 
   (reify
     ;; Reflection defines "What :f functions does this nemesis support?"
-    n/Reflection
-    (fs [_] [:add-member :remove-member]))
-
-    n/Nemesis
+    jnem/Reflection
+    (fs [_] [:add-member :remove-member])
+  
+    jnem/Nemesis
     ;; Setup the nemesis to work with the cluster. Returns the nemesis ready to be invoked.
-    (setup! [this test] (info node "Setting up member nemesis"))
+    (setup! [this test] (info "Setting up member nemesis"))
 
     ;; Invoke - perform acture add and remove of members
     (invoke! [this test op]
@@ -118,7 +119,8 @@
     ) 
 
     ;; Teardown the nemesis when work is complete
-    (teardown! [this test] (info node "Tearing down member nemesis"))
+    (teardown! [this test] (info "Tearing down member nemesis"))
+  )
 )
 
 
@@ -128,14 +130,14 @@
   (let
     [
       db (:db opts),
-      nodes: (:nodes opts),
+      nodes (:nodes opts),
       rm {:type :info, :f :remove-members},
       ad {:type :info, :f :add-members}
     ]
     ;; A simple logic is to remove -> add -> remove -> add .... repeat
     (->>
-      (gen/flip-flop rm ad)
-      (gen/stagger (:interval opts default-interval))
+      (jgen/flip-flop rm ad)
+      (jgen/stagger (:interval opts 10))
     )
   )
 )

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -17,8 +17,8 @@
 )) 
 
 (def version-cnt (
-  ref #{} 
-  ;; :validator pos? ;; there might need a validator
+  ref 1 
+  :validator pos? ;; there might need a validator
 )) 
 
 (defn construct-config
@@ -39,21 +39,22 @@
     ;; }
     ;; Each replica set member must have a unique _id. Avoid re-using _id values even if no members[n] entry is using that _id in the current configuration.
     ;; Once set, you cannot change the _id of a member.    
-    :members (->>
-      members
-      (map-indexed (fn [i node]
-                                  {:_id  i
-                                   :priority (if (hidden node)
-                                               0
-                                               (- (count (:nodes test)) i))
-                                   :votes    (if (hidden node)
-                                               0
-                                               1)
-                                   :hidden   (boolean (hidden node))
-                                   :host     (str node ":"
-                                                  (if (config-server? test)
-                                                    client/config-port
-                                                    client/shard-port))})))}
+    ;; :members (->>
+    ;;   members
+    ;;   (map-indexed (fn [i node]
+    ;;                               {:_id  i
+    ;;                                :priority (if (hidden node)
+    ;;                                            0
+    ;;                                            (- (count (:nodes test)) i))
+    ;;                                :votes    (if (hidden node)
+    ;;                                            0
+    ;;                                            1)
+    ;;                                :hidden   (boolean (hidden node))
+    ;;                                :host     (str node ":"
+    ;;                                               (if (config-server? test)
+    ;;                                                 client/config-port
+    ;;                                                 client/shard-port))})))
+    }
 )
 
 
@@ -69,37 +70,42 @@
       rm-seq (seq removed)
       ;; live-members (cset/difference (set nodes) removed)
     ]
-    (for [n rm-seq]
-      (let
-        [
-          cur_prim (->>
-            (cset/difference (set nodes) removed) ;; calculate remaining alive nodes
-            (assoc test :nodes) ;; for following code, we only need to check alive nodes
-            (db/primaries replica-set-db)
-            (first));; get only the first result
-        ]
-        (info "current primary is " cur_prim)
-        
-        (with-open [ conn (mcl/open cur_prim port) ]
-          (let
-            [
-              old-config (:config (mcl/admin-command! conn { :replSetGetConfig 1 }))
-              id (:_id old-config)
-              ;; new-version (+ (:version old-config) 1)
-              ;; TODO: get the member list by removing 1 member
-              new-members (vec (filter #(not= (:host %) n) (:members old-config)))
-              ;; TODO: construct new config
-              new-config {:_id id, :members new-members}
-            ]
-            ;; TODO: call reconfig
-            (try
-              ;; the below command should act as rs.remove()
-              ;; This function will disconnect the shell briefly and forces a reconnection
-              ;; the shell will display an error even if this command succeeds
-              (mcl/admin-command! conn { :replSetReconfig new-config })
-              (catch Exception e (info "Reconfig should have completed, the error is\n" e) nil)
+    (doall
+      (for [n rm-seq]
+        (let
+          [
+            cur_prim (->>
+              (cset/difference (set nodes) removed) ;; calculate remaining alive nodes
+              (assoc test :nodes) ;; for following code, we only need to check alive nodes
+              (db/primaries replica-set-db)
+              (first));; get only the first result
+            old-version (deref version-cnt)
+            new-version (+ old-version 1)
+          ]
+          (info "in grace remove, node " n ". current primary is " cur_prim " port is " port)
+          (with-open [ conn (mcl/open cur_prim port) ]
+            (let
+              [
+                old-config (:config (mcl/admin-command! conn { :replSetGetConfig 1 }))
+                id (:_id old-config)
+                ;; new-version (+ (:version old-config) 1)
+                ;; TODO: get the member list by removing 1 member
+                new-members (vec (filter #(not= (mcl/addr->node (:host %)) n) (:members old-config)))
+                ;; TODO: construct new config
+                new-config {:_id id, :version new-version, :members new-members}
+              ]
+              ;; TODO: call reconfig
+              (try
+                ;; the below command should act as rs.remove()
+                ;; This function will disconnect the shell briefly and forces a reconnection
+                ;; the shell will display an error even if this command succeeds
+                (mcl/admin-command! conn { :replSetReconfig new-config })
+                (catch Exception e (info "Reconfig should have completed, the error is\n" e) nil)
+              )
+              ;; TODO: update version cnt
+              (dosync (ref-set version-cnt new-version))
+              (info "cleaned up for " n)
             )
-            (info "cleaned up for " n)
           )
         )
       )
@@ -135,9 +141,9 @@
     ;; )
     ;; (info "New primary after rs.remove is " primary)
     ;; ;; (.close (mcl/await-open primary port)) ;; wait for primary to connect
-    ;; (with-open [ conn (mcl/open primary port) ]
-    ;;   (info "Current config\n: "  (mcl/admin-command! conn { :replSetGetConfig 1 })) ;; get current config
-    ;; )
+    (with-open [ conn (mcl/open primary port) ]
+      (info "In add-with-reconfig, Current config:\n\n "  (mcl/admin-command! conn { :replSetGetConfig 1 }) "\n\n") ;; get current config
+    )
     
   )
 )
@@ -165,9 +171,6 @@
           replica-set-db (:db test),
           nodes (:nodes test)
         ]
-        ;; update status
-        (dosync (ref-set crashing-status (cset/difference removed (set target))))
-        (info "Add member " target " new crashing status is " (deref crashing-status))
         ;; Now add new members step by step
         ;; 1. the kill didn't follow the remove procedure defined by mongodb, so follow here
         (grace-remove-cleanup test replica-set-db nodes removed)
@@ -178,6 +181,9 @@
         ;; 2.2 Add the new member into the replica set
         (add-with-reconfig test replica-set-db nodes target)
 
+        ;; update status
+        (dosync (ref-set crashing-status (cset/difference removed (set target))))
+        (info "Add member " target " new crashing status is " (deref crashing-status))
         ;; (configure! test node) ;; seems can skip config since it should have been setup properly
         ;; (start! test node) ;;
         ;; (join! test node)
@@ -252,7 +258,7 @@
     ;; Setup the nemesis to work with the cluster. Returns the nemesis ready to be invoked.
     (setup! [this test]
       (info "Setting up member nemesis")
-      (dosync (ref-set version-cnt (count (:nodes test)))) ;; track the version number
+      (dosync (ref-set version-cnt 1))) ;; track the version number
       this
     )
 

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -30,7 +30,7 @@
         (db/primaries replica-set-db)
         (first) ;; get only the first result
       ) ;; determing current primary
-      port mcl/config-port
+      port (if (mdb/config-server? test) mcl/config-port mcl/shard-port)
       host-port-list (-> (fn [n] (str n ":" port))
         (map removed)
         vec
@@ -40,6 +40,7 @@
     (info "finish up remove before add on " host-port-list)
     ;; let primary finish remaing remove steps
     (with-open [ conn (mcl/open cur_prim port) ]
+      ;; (info "Current config\n: "  (mcl/admin-command! conn { :replSetGetConfig 1 })) ;; get current config
       ;; the below command should act as rs.remove()
       ;; This function will disconnect the shell briefly and forces a reconnection
       ;; the shell will display an error even if this command succeeds
@@ -50,6 +51,37 @@
     )
   )
 )
+
+
+(defn add-with-reconfig
+  ""
+  [test, replica-set-db, nodes, target]
+  (let
+    [
+      primary (->>
+        (cset/difference (set nodes) target) ;; calculate remaining alive nodes
+        (assoc test :nodes) ;; for following code, we only need to check alive nodes
+        (db/primaries replica-set-db)
+        (first) ;; get only the first result
+      )
+      port (if (mdb/config-server? test) mcl/config-port mcl/shard-port)
+    ]
+    ;; db.adminCommand(
+    ;;   {
+    ;;     replSetGetConfig: 1,
+    ;;     commitmentStatus: <boolean>,
+    ;;     comment: <any>
+    ;;   }
+    ;; )
+    (info "New primary after rs.remove is " primary)
+    ;; (.close (mcl/await-open primary port)) ;; wait for primary to connect
+    (with-open [ conn (mcl/open primary port) ]
+      (info "Current config\n: "  (mcl/admin-command! conn { :replSetGetConfig 1 })) ;; get current config
+    )
+    
+  )
+)
+
 
 (defn add-members
   "Add voting members into the replica set.
@@ -79,35 +111,18 @@
         ;; Now add new members step by step
         ;; 1. the kill didn't follow the remove procedure defined by mongodb, so follow here
         (grace-remove-cleanup test replica-set-db nodes removed)
-        ;; 2. TODO: now (re)-add new members
-        ;; (let
-        ;;   [
-        ;;     cur_prim (->>
-        ;;       (cset/difference (set nodes) removed) ;; calculate remaining alive nodes
-        ;;       (assoc test :nodes) ;; for following code, we only need to check alive nodes
-        ;;       (db/primaries replica-set-db)
-        ;;       (first) ;; get only the first result
-        ;;     ) ;; determing current primary
-        ;;     port mcl/config-port
-        ;;     host-port-list (-> (fn [n] (str n ":" port))
-        ;;       (map removed)
-        ;;       vec
-        ;;     ) ;; get a vector of to removed
-        ;;   ]
-        ;;   (info "primary before add is " cur_prim)
-        ;;   (info "finish up remove before add on " host-port-list)
-        ;;   ;; let primary finish remaing remove steps
-        ;;   (with-open [ conn (mcl/open cur_prim port) ]
-        ;;     ;; the below command should act as rs.remove()
-        ;;     ;; This function will disconnect the shell briefly and forces a reconnection
-        ;;     ;; the shell will display an error even if this command succeeds
-        ;;     (try
-        ;;       (mcl/admin-command! conn { :dropConnections 1, :hostAndPort host-port-list })
-        ;;       (catch Exception e (info "drop should have completed") nil)
-        ;;     )
-        ;;   )
-        ;;   ;;
-        ;; )
+        ;; 2. now (re)-add new members
+        ;; 2.1 Make sure the new member's data directory does not contain data
+        (jcontrol/on-nodes test removed mdb/wipe!)
+        (info "Should have removed old data")
+        ;; 2.2 Add the new member into the replica set
+        (add-with-reconfig test replica-set-db nodes target)
+
+        ;; (configure! test node) ;; seems can skip config since it should have been setup properly
+        ;; (start! test node) ;;
+        ;; (join! test node)
+        ;; (jcontrol/on-nodes test target (partial db/kill! replica-set-db))
+
       )
       (info "No adding any member")
     )

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -57,21 +57,20 @@
               [
                 old-config (:config (mcl/admin-command! conn { :replSetGetConfig 1 }))
                 id (:_id old-config)
-                ;; new-version (+ (:version old-config) 1)
-                ;; TODO: get the member list by removing 1 member
+                ;; Get the member list by removing 1 member
                 new-members (vec (filter #(not= (mcl/addr->node (:host %)) n) (:members old-config)))
-                ;; TODO: construct new config
+                ;; Construct new config
                 new-config {:_id id, :version new-version, :members new-members}
               ]
-              ;; TODO: call reconfig
-              (try
+              ;; Reconfig to remove
+              ;; (try
                 ;; the below command should act as rs.remove()
                 ;; This function will disconnect the shell briefly and forces a reconnection
                 ;; the shell will display an error even if this command succeeds
                 (mcl/admin-command! conn { :replSetReconfig new-config })
-                (catch Exception e (info "Reconfig should have completed, the error is\n" e) nil)
-              )
-              ;; TODO: update version cnt
+              ;;   (catch Exception e (info "Reconfig should have completed, the error is\n" e) nil)
+              ;; )
+              ;; Update version cnt
               (dosync (ref-set version-cnt new-version))
               (info "cleaned up for " n)
             )
@@ -109,10 +108,10 @@
         new-config {:_id id, :version new-version, :members new-member-list}
       ]
       (info "New member list is: ", new-member-list)
-      (try
+      ;; (try
         (mcl/admin-command! conn { :replSetReconfig new-config })
-        (catch Exception e (info "Reconfig should have completed, the error is\n" e) nil)
-      )
+      ;;   (catch Exception e (info "Reconfig should have completed, the error is\n" e) nil)
+      ;; )
       ;; update version-cnt and member-id-cnt
       (dosync (ref-set version-cnt new-version))
       (dosync (ref-set member-id-cnt new-member-id))
@@ -156,35 +155,94 @@
 )
 
 
+(defn force-reconfig
+  "When there are less than 3 nodes available in the cluster, force a reconfig"
+  [test, replica-set-db, nodes, removed]
+  (let
+    [
+      live-members (cset/difference (set nodes) removed), ;; members that are alive before add
+      live-x (first live-members),
+      port (if (mdb/config-server? test) mcl/config-port mcl/shard-port)
+    ]
+    ;; 2. Start the mongod for all
+    (jcontrol/on-nodes test removed mdb/start!)
+    (info "In FORCE, restarted mongod")
+    ;; 2. Force a reconfig
+    (with-open [ live-conn (mcl/open live-x port) ]
+      (let
+        [
+          cur-config (mcl/admin-command! live-conn { replSetGetConfig: 1 }) ;; get the current configuration
+          id (:_id old-config)
+          old-version (deref version-cnt)
+          new-version (+ old-version 1)
+          old-member-list (:members old-config)
+          ;; Each replica set member must have a unique _id. Avoid re-using _id values even if no members[n] entry is using that _id in the current configuration.
+          old-member-id (deref member-id-cnt)
+          new-member-list (->> (vec removed)
+            ;; Construct a new member document for each new member
+            ;; For now only add voting members and doesn't consider hidden problem, for simplicity set priority be 1
+            (map-indexed (fn [i to-add] {:_id (+ new-member-id-base i 1), :votes 1, :host (str to-add ":" port), :priority 1, :hidden false}))
+            ;; add with old member list
+            (concat (vec old-member-list))
+          )
+          ;; Construct new config with force
+          new-config {:_id id, :version new-version, :members new-member-list, :force true}
+        ]
+        (info "The new FORCE config is:\n" new-config)
+        ;; enforce a reconfig
+        ;; according to MongoDB, the configuration is then propagated to all the surviving members listed in the members array. The replica set will then
+        ;; elects a new primary.
+        (mcl/admin-command! live-conn { :replSetReconfig new-config })
+        ;; update version-cnt and member-id-cnt
+        (dosync (ref-set version-cnt new-version))
+        (dosync (ref-set member-id-cnt (+ old-member-id (count removed))))
+        (info "End of FORCE reconfig. Added " removed "via force reconfiguration.")
+      )
+    )
+  )
+)
+
+
 (defn add-members
   "Add voting members into the replica set.
   As required by MongoDB, assume add even numbers of members.
   "
   [test]
-  (info "joining the replica set" )
+  ;; (info "joining the replica set" )
   (let
     [
       removed (deref crashing-status) ;; removed count should always be even
-      cnt (count removed)
+      removed-cnt (count removed)
+      nodes (:nodes test)
+      remaining-cnt (- (count nodes) removed-cnt)
+      replica-set-db (:db test)
     ]
 
-    (if (pos? cnt)
-      ;; if there are removed members, add some back
+    ;; 1. the kill didn't follow the remove procedure defined by mongodb, so follow here
+    (grace-remove-cleanup test replica-set-db nodes removed)
+    ;; 2.1 Make sure the new member's data directory does not contain data
+    (jcontrol/on-nodes test removed mdb/wipe!)
+    (info "Should have removed old data")
+
+    ;; (if (pos? cnt)
+    (if (>= remaining-cnt 3)
+      ;; if the replica set has more than 3 members, can just add with reconfig
       (let
         [
-          rnd (+ (rand-int cnt) 1),  ;; rnd = 1 ~ cnt, cnt itself should be even
-          num (if (even? rnd) rnd (+ rnd 1)), ;; ensure add > 0 and even
-          target (take num (shuffle removed)),
-          replica-set-db (:db test),
-          nodes (:nodes test)
+          ;; rnd (+ (rand-int cnt) 1),  ;; rnd = 1 ~ cnt, cnt itself should be even
+          ;; num (if (even? rnd) rnd (+ rnd 1)), ;; ensure add > 0 and even
+          ;; target (take num (shuffle removed)),
+          target (set removed), ;; add back all removed
+          ;; replica-set-db (:db test)
+          ;; nodes (:nodes test)
         ]
         ;; Now add new members step by step
         ;; 1. the kill didn't follow the remove procedure defined by mongodb, so follow here
-        (grace-remove-cleanup test replica-set-db nodes removed)
+        ;; (grace-remove-cleanup test replica-set-db nodes removed)
         ;; 2. now (re)-add new members
         ;; 2.1 Make sure the new member's data directory does not contain data
-        (jcontrol/on-nodes test removed mdb/wipe!)
-        (info "Should have removed old data")
+        ;; (jcontrol/on-nodes test removed mdb/wipe!)
+        ;; (info "Should have removed old data")
         ;; 2.2 Add the new member into the replica set
         (add-with-reconfig test replica-set-db nodes target)
 
@@ -192,7 +250,37 @@
         (dosync (ref-set crashing-status (cset/difference removed (set target))))
         (info "Add member " target " new crashing status is " (deref crashing-status))
       )
-      (info "No adding any member")
+      ;; Otherwise, should have no primary now, need to force a reconfiguration
+      (force-reconfig test replica-set-db nodes removed)
+    )
+  )
+)
+
+
+(defn parse-options
+  "Return a set of nodes based on the options
+    :primary         - Choose only the primary node
+    :minority        - Choose a random minority of nodes so that after remove the remaining members >= 3
+    :majority        - Choose a random majority of nodes so that after remove the remaining members < 3
+    ;; TODO:
+    :all             - Choose all nodes
+    :one             - Chooses a single random node
+  "
+  [test, options]
+  (let
+    [
+      nodes (:nodes test)
+      db (:db test)
+      saft-num (- (count nodes) 3)
+      minority-num (+ (rand-int saft-num) 1) ;; = 1 ~ saftnum
+      majority-num (- (count nodes) (+ (rand-int 2) 1)) ;; = total number - (1 ~ 2)
+    ]
+    (case options
+      :primary    (set (db/primaries db test)) ;; here assume all nodes should be available
+      :minority   (take minority-num (shuffle nodes))
+      :majority   (take majority-num (shuffle nodes))
+      ;; :one        (list (rand-nth nodes))
+      ;; :all        nodes
     )
   )
 )
@@ -202,34 +290,37 @@
   "Forcibly remove voting members from the replica set (i.e. kill mongod process) to simulate crashes
   As required by MongoDB, assume remove even numbers of members 
   "
-  [test]
+  [test, options]
   (info "Start removing members")
   (let
     [
       nodes (:nodes test), ;; all nodes in a test
-      removed (deref crashing-status),
-      avail (cset/difference (set nodes) removed), ;; still available nodes
-      avail-cnt (- (count avail) 3) ;; # of nodes that can be removed
+      replica-set-db (:db test)
+      target (parse-options test options)
+      ;; removed (deref crashing-status),
+      ;; avail (cset/difference (set nodes) removed), ;; still available nodes
+      ;; avail-cnt (- (count avail) 3) ;; # of nodes that can be removed
     ]
-    (info "have " avail-cnt "members can be removed. Current crashing status is ", removed)
-    (if (pos? avail-cnt)
-      ;; if there are members available to remove, then do a random remove of even # of members
-      (let
-        [
-          rnd (+ (rand-int avail-cnt) 1), ;; rnd = 1 ~ avail-cnt, where avail-cnt should be even
-          num (if (even? rnd) rnd (+ rnd 1)), ;; ensure remove > 0 and even
-          target (take num (shuffle avail)) ;; randomly choose from nodes
-          replica-set-db (:db test)
-        ]
-        ;; update status
-        (dosync (ref-set crashing-status (cset/union removed (set target))))
-        (info "remove nodes " target " new crashing status is " (deref crashing-status))
+    ;; (info "have " avail-cnt "members can be removed. Current crashing status is ", removed)
+    ;; (if (pos? avail-cnt)
+      ;; if there are members available to remove, then do a random remove of # of members
+      ;; (let
+      ;;   [
+      ;;     ;; rnd (+ (rand-int avail-cnt) 1), ;; rnd = 1 ~ avail-cnt, where avail-cnt should be even
+      ;;     ;; num (if (even? rnd) rnd (+ rnd 1)), ;; ensure remove > 0 and even
+      ;;     ;; num (+ (rand-int avail-cnt) 1), ;; num = 1 ~ avail-cnt
+      ;;     ;; target (take num (shuffle avail)) ;; randomly choose from nodes
+      ;;     replica-set-db (:db test)
+      ;;   ]
         ;; apply kill on all the targets
         (jcontrol/on-nodes test target (partial db/kill! replica-set-db))
-      )
+        ;; update status
+        (dosync (ref-set crashing-status (set target)))
+        (info "remove nodes " target " new crashing status is " (deref crashing-status))
+      ;; )
       ;; otherwise, just not removing any node
-      (info "Not removing any node")
-    )
+      ;; (info "Not removing any node")
+    ;; )
   )
 )
 
@@ -269,8 +360,8 @@
     (invoke! [this test op]
       (assoc op :value
         (case (:f op)
-          :add-members     (add-members test) ;; TODO
-          :remove-members   (remove-members test) ;; TODO
+          :add-members     (add-members test)
+          :remove-members   (remove-members test (:value op))
         ))
     ) 
 
@@ -285,10 +376,9 @@
   [opts]
   (let
     [
-      ;; db (:db opts),
-      ;; nodes (:nodes opts),
-      rm (fn [_ _] {:type :info, :f :remove-members}),
-      ad (fn [_ _] {:type :info, :f :add-members})
+      remove-options (:targets (:member opts) [:primary :minority :majority])
+      rm (fn [_ _] {:type :info, :f :remove-members, :value (rand-nth remove-options)}),
+      ad (fn [_ _] {:type :info, :f :add-members}, :value :all)
     ]
     ;; A simple logic is to remove -> add -> remove -> add .... repeat
     (->>

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/member_nem.clj
@@ -106,6 +106,7 @@
           (conj (vec old-member-list))
         )
         ;; Construct new config
+        (info "New member list is: ", new-member-list)
         new-config {:_id id, :version new-version, :members new-member-list}
       ]
       (try

--- a/tests/jepsen/mongodb/src/jepsen/mongodb/nemesis.clj
+++ b/tests/jepsen/mongodb/src/jepsen/mongodb/nemesis.clj
@@ -9,7 +9,8 @@
             [jepsen.generator :as gen]
             [jepsen.nemesis [combined :as nc]
                             [time :as nt]]
-            [jepsen.mongodb.db :as db]))
+            [jepsen.mongodb [db :as db]
+                            [member-nem :as nemmember]]))
 
 (defn shard-generator
   "Takes a collection of shard packages, and returns a generator that emits ops
@@ -88,5 +89,7 @@
                   (update :faults set))]
     (-> (if (:sharded opts')
           (sharded-nemesis-package opts')
-          (nc/nemesis-package opts'))
+          ;; (nc/nemesis-package opts'))
+          ;; need to combine provided nemesis-package and member nemesis
+          (nc/compose-packages (concat (nc/nemesis-packages opts')  [(nemmember/member-package opts')]) ) )
         (update :generator (partial gen/delay (:interval opts))))))


### PR DESCRIPTION
Address #2.

This simple version would introduce a nemesis about replica set members, targeting **only** the **non-Sharded** db (aka. replica-set-db) https://github.com/sasoripathos/mallory/blob/a9c4c31c98c3ba8d69fc0a46169eb64057b726a7/tests/jepsen/mongodb/src/jepsen/mongodb/db.clj#L276

This nemesis will kill the mongod process to simulate a member crash, it would try recover members with the MongoDB's reconfiguration command. This is different from